### PR TITLE
Fix lidarr_search term handling and output fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-arr-server",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-arr-server",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "bin": {
         "mcp-arr": "dist/index.js"

--- a/src/arr-client.ts
+++ b/src/arr-client.ts
@@ -438,6 +438,8 @@ export interface SearchResult {
   imdbId?: string;
   // Lidarr specific
   foreignArtistId?: string;
+  artistName?: string;
+  disambiguation?: string;
   // Readarr specific
   foreignAuthorId?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1301,7 +1301,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "lidarr_search": {
         if (!clients.lidarr) throw new Error("Lidarr not configured");
-        const term = (args as { term: string }).term;
+        const a = args as { term?: string; query?: string; artist?: string; name?: string };
+        const term = a.term ?? a.query ?? a.artist ?? a.name;
+        if (!term) throw new Error("term required (artist name)");
         const results = await clients.lidarr.searchArtists(term);
         return {
           content: [{
@@ -1309,9 +1311,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             text: JSON.stringify({
               count: results.length,
               results: results.slice(0, 10).map(r => ({
-                title: r.title,
+                artistName: r.artistName ?? r.title,
+                disambiguation: r.disambiguation,
                 foreignArtistId: r.foreignArtistId,
-                overview: r.overview?.substring(0, 200) + (r.overview && r.overview.length > 200 ? '...' : ''),
+                overview: r.overview ? (r.overview.substring(0, 200) + (r.overview.length > 200 ? '...' : '')) : undefined,
               })),
             }, null, 2),
           }],


### PR DESCRIPTION
## Summary
- Accept lidarr_search term from term|query|artist|name and validate non-empty input
- Return Lidarr-specific fields (artistName, disambiguation, foreignArtistId) plus trimmed overview
- Extend SearchResult typing to include Lidarr artist fields

## Problem
lidarr_search only read "term" and returned "title/overview". Lidarr artist lookup results provide artistName/disambiguation; if callers used query/artist, the term was undefined and results were empty or misleading.

## Testing
- npm run build
- MCP call: arr.lidarr_search(term: "Foxing") returned expected artistName/disambiguation
