### PR TITLE
feat: add refresh tools and paginate large library listings

### DIFF
--- a/src/arr-client.ts
+++ b/src/arr-client.ts
@@ -605,6 +605,19 @@ export class SonarrClient extends ArrClient {
       }),
     });
   }
+
+  /**
+   * Trigger a refresh for a specific series
+   */
+  async refreshSeries(seriesId: number): Promise<{ id: number }> {
+    return this['request']<{ id: number }>('/command', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'RefreshSeries',
+        seriesId,
+      }),
+    });
+  }
 }
 
 export class RadarrClient extends ArrClient {
@@ -657,6 +670,19 @@ export class RadarrClient extends ArrClient {
       method: 'POST',
       body: JSON.stringify({
         name: 'MoviesSearch',
+        movieIds: [movieId],
+      }),
+    });
+  }
+
+  /**
+   * Trigger a refresh for a specific movie
+   */
+  async refreshMovie(movieId: number): Promise<{ id: number }> {
+    return this['request']<{ id: number }>('/command', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'RefreshMovie',
         movieIds: [movieId],
       }),
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,6 +266,20 @@ if (clients.sonarr) {
       },
     },
     {
+      name: "sonarr_refresh_series",
+      description: "Trigger a metadata refresh for a specific series in Sonarr",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          seriesId: {
+            type: "number",
+            description: "Series ID to refresh",
+          },
+        },
+        required: ["seriesId"],
+      },
+    },
+    {
       name: "sonarr_add_series",
       description: "Add a TV series to Sonarr. Use sonarr_search first to find the tvdbId, and sonarr_get_root_folders / sonarr_get_quality_profiles to get valid values for rootFolderPath and qualityProfileId. Use sonarr_get_tags to get valid tag IDs.",
       inputSchema: {
@@ -365,6 +379,20 @@ if (clients.radarr) {
           movieId: {
             type: "number",
             description: "Movie ID to search for",
+          },
+        },
+        required: ["movieId"],
+      },
+    },
+    {
+      name: "radarr_refresh_movie",
+      description: "Trigger a metadata refresh for a specific movie in Radarr",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          movieId: {
+            type: "number",
+            description: "Movie ID to refresh",
           },
         },
         required: ["movieId"],
@@ -1217,6 +1245,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
+      case "sonarr_refresh_series": {
+        if (!clients.sonarr) throw new Error("Sonarr not configured");
+        const seriesId = (args as { seriesId: number }).seriesId;
+        const result = await clients.sonarr.refreshSeries(seriesId);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              success: true,
+              message: `Refresh triggered for series`,
+              commandId: result.id,
+            }, null, 2),
+          }],
+        };
+      }
+
       case "sonarr_add_series": {
         if (!clients.sonarr) throw new Error("Sonarr not configured");
         const { tvdbId, title, qualityProfileId, rootFolderPath, monitored, seasonFolder, tags } = args as {
@@ -1326,6 +1370,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             text: JSON.stringify({
               success: true,
               message: `Search triggered for movie`,
+              commandId: result.id,
+            }, null, 2),
+          }],
+        };
+      }
+
+      case "radarr_refresh_movie": {
+        if (!clients.radarr) throw new Error("Radarr not configured");
+        const movieId = (args as { movieId: number }).movieId;
+        const result = await clients.radarr.refreshMovie(movieId);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              success: true,
+              message: `Refresh triggered for movie`,
               commandId: result.id,
             }, null, 2),
           }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,10 +174,23 @@ if (clients.sonarr) {
   TOOLS.push(
     {
       name: "sonarr_get_series",
-      description: "Get all TV series in Sonarr library",
+      description: "Get TV series from Sonarr library with optional pagination and title filtering. Defaults to limit=25 to avoid very large responses. Use offset to fetch additional pages.",
       inputSchema: {
         type: "object" as const,
-        properties: {},
+        properties: {
+          limit: {
+            type: "number",
+            description: "Maximum number of series to return (default: 25, max: 100)",
+          },
+          offset: {
+            type: "number",
+            description: "Number of series to skip before returning results (default: 0)",
+          },
+          search: {
+            type: "string",
+            description: "Optional case-insensitive title filter",
+          },
+        },
         required: [],
       },
     },
@@ -326,10 +339,23 @@ if (clients.radarr) {
   TOOLS.push(
     {
       name: "radarr_get_movies",
-      description: "Get all movies in Radarr library",
+      description: "Get movies from Radarr library with optional pagination and title filtering. Defaults to limit=25 to avoid very large responses. Use offset to fetch additional pages.",
       inputSchema: {
         type: "object" as const,
-        properties: {},
+        properties: {
+          limit: {
+            type: "number",
+            description: "Maximum number of movies to return (default: 25, max: 100)",
+          },
+          offset: {
+            type: "number",
+            description: "Number of movies to skip before returning results (default: 0)",
+          },
+          search: {
+            type: "string",
+            description: "Optional case-insensitive title filter",
+          },
+        },
         required: [],
       },
     },
@@ -1117,13 +1143,35 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // Sonarr handlers
       case "sonarr_get_series": {
         if (!clients.sonarr) throw new Error("Sonarr not configured");
-        const series = await clients.sonarr.getSeries();
+        const { limit = 25, offset = 0, search } = args as {
+          limit?: number;
+          offset?: number;
+          search?: string;
+        };
+        const normalizedLimit = Math.max(1, Math.min(limit, 100));
+        const normalizedOffset = Math.max(0, offset);
+        const filter = search?.trim().toLowerCase();
+
+        const allSeries = await clients.sonarr.getSeries();
+        const filteredSeries = filter
+          ? allSeries.filter(s => s.title.toLowerCase().includes(filter))
+          : allSeries;
+        const pagedSeries = filteredSeries.slice(normalizedOffset, normalizedOffset + normalizedLimit);
         return {
           content: [{
             type: "text",
             text: JSON.stringify({
-              count: series.length,
-              series: series.map(s => ({
+              total: allSeries.length,
+              filteredCount: filteredSeries.length,
+              returned: pagedSeries.length,
+              offset: normalizedOffset,
+              limit: normalizedLimit,
+              hasMore: normalizedOffset + normalizedLimit < filteredSeries.length,
+              nextOffset: normalizedOffset + normalizedLimit < filteredSeries.length
+                ? normalizedOffset + normalizedLimit
+                : null,
+              search: search ?? null,
+              series: pagedSeries.map(s => ({
                 id: s.id,
                 title: s.title,
                 year: s.year,
@@ -1248,6 +1296,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "sonarr_refresh_series": {
         if (!clients.sonarr) throw new Error("Sonarr not configured");
         const seriesId = (args as { seriesId: number }).seriesId;
+        const series = await clients.sonarr.getSeriesById(seriesId);
         const result = await clients.sonarr.refreshSeries(seriesId);
         return {
           content: [{
@@ -1255,6 +1304,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             text: JSON.stringify({
               success: true,
               message: `Refresh triggered for series`,
+              series: {
+                id: series.id,
+                title: series.title,
+                year: series.year,
+              },
               commandId: result.id,
             }, null, 2),
           }],
@@ -1287,13 +1341,35 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // Radarr handlers
       case "radarr_get_movies": {
         if (!clients.radarr) throw new Error("Radarr not configured");
-        const movies = await clients.radarr.getMovies();
+        const { limit = 25, offset = 0, search } = args as {
+          limit?: number;
+          offset?: number;
+          search?: string;
+        };
+        const normalizedLimit = Math.max(1, Math.min(limit, 100));
+        const normalizedOffset = Math.max(0, offset);
+        const filter = search?.trim().toLowerCase();
+
+        const allMovies = await clients.radarr.getMovies();
+        const filteredMovies = filter
+          ? allMovies.filter(m => m.title.toLowerCase().includes(filter))
+          : allMovies;
+        const pagedMovies = filteredMovies.slice(normalizedOffset, normalizedOffset + normalizedLimit);
         return {
           content: [{
             type: "text",
             text: JSON.stringify({
-              count: movies.length,
-              movies: movies.map(m => ({
+              total: allMovies.length,
+              filteredCount: filteredMovies.length,
+              returned: pagedMovies.length,
+              offset: normalizedOffset,
+              limit: normalizedLimit,
+              hasMore: normalizedOffset + normalizedLimit < filteredMovies.length,
+              nextOffset: normalizedOffset + normalizedLimit < filteredMovies.length
+                ? normalizedOffset + normalizedLimit
+                : null,
+              search: search ?? null,
+              movies: pagedMovies.map(m => ({
                 id: m.id,
                 title: m.title,
                 year: m.year,
@@ -1379,6 +1455,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "radarr_refresh_movie": {
         if (!clients.radarr) throw new Error("Radarr not configured");
         const movieId = (args as { movieId: number }).movieId;
+        const movie = await clients.radarr.getMovieById(movieId);
         const result = await clients.radarr.refreshMovie(movieId);
         return {
           content: [{
@@ -1386,6 +1463,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             text: JSON.stringify({
               success: true,
               message: `Refresh triggered for movie`,
+              movie: {
+                id: movie.id,
+                title: movie.title,
+                year: movie.year,
+              },
               commandId: result.id,
             }, null, 2),
           }],


### PR DESCRIPTION
## Summary

This PR adds two new refresh tools and improves large library listing behavior to reduce oversized MCP responses.

Added:
- `sonarr_refresh_series`
- `radarr_refresh_movie`

Improved:
- `sonarr_get_series`
- `radarr_get_movies`

## Why

Two issues came up while using the server in an MCP workflow:

1. There was no direct tool for triggering a targeted refresh on an existing series or movie.
2. Large library listing tools could return very large responses and quickly fill MCP context.

This PR addresses both problems.

## What Changed

### New refresh tools

Added:
- `sonarr_refresh_series`
- `radarr_refresh_movie`

Implementation details:
- added `SonarrClient.refreshSeries(seriesId)`
- added `RadarrClient.refreshMovie(movieId)`
- added matching MCP tool definitions and handlers

### Refresh target validation

The refresh handlers now validate that the target exists before sending the refresh command:
- `sonarr_refresh_series` calls `getSeriesById(seriesId)` first
- `radarr_refresh_movie` calls `getMovieById(movieId)` first

This prevents false-positive success responses when an invalid ID is supplied.

Successful refresh responses now also include the validated target:
- `id`
- `title`
- `year`

### Pagination for large library listings

Updated:
- `sonarr_get_series`
- `radarr_get_movies`

These tools now support optional:
- `limit`
- `offset`
- `search`

Behavior:
- default `limit` is `25`
- max `limit` is `100`
- `search` applies a case-insensitive title filter
- responses include:
  - `total`
  - `filteredCount`
  - `returned`
  - `offset`
  - `limit`
  - `hasMore`
  - `nextOffset`

This keeps normal MCP responses much smaller while still allowing full pagination through larger libraries.

## Example Usage

### Refresh tools

- "Refresh this series in Sonarr"
- "Trigger a metadata refresh for movie ID 123 in Radarr"

### Paginated listings

- `sonarr_get_series {}`
- `sonarr_get_series { "limit": 10, "offset": 10 }`
- `sonarr_get_series { "search": "office", "limit": 5 }`
- `radarr_get_movies { "limit": 25, "offset": 25 }`

## Testing

Ran locally:
- `npm install`
- `npm run build`

The project builds successfully with these changes.

## Notes

This keeps the implementation consistent with the existing command-based mutation pattern already used by tools such as:
- `sonarr_search_missing`
- `sonarr_search_episode`
- `radarr_search_movie`

The pagination changes are intended to make the server more practical in real MCP usage where full-library responses can consume too much context.
