### PR TITLE
CI: add release pipeline with Docker, GHCR, npm publish and GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,194 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 1.6.4) — must exist in CHANGELOG.md'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  # ── 1. Validate & prepare ──────────────────────────────────────────────────
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      tag:     ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
+      major:   ${{ steps.version.outputs.major }}
+      minor:   ${{ steps.version.outputs.minor }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # needed to inspect existing tags
+
+      - name: Resolve and validate version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+            TAG="v${VERSION}"
+
+            # If the tag already exists, make sure it points to HEAD
+            if git rev-parse "${TAG}" >/dev/null 2>&1; then
+              TAG_SHA=$(git rev-parse "${TAG}")
+              HEAD_SHA=$(git rev-parse HEAD)
+              if [ "${TAG_SHA}" != "${HEAD_SHA}" ]; then
+                echo "::error::Tag ${TAG} already exists and points to ${TAG_SHA}, not HEAD (${HEAD_SHA}). Aborting."
+                exit 1
+              fi
+              echo "Tag ${TAG} already exists and matches HEAD — reusing."
+            else
+              git config user.name "github-actions[bot]"
+              git config user.email "github-actions[bot]@users.noreply.github.com"
+              git tag "${TAG}"
+              git push origin "${TAG}"
+            fi
+          else
+            TAG="${GITHUB_REF_NAME}"
+            VERSION="${TAG#v}"
+          fi
+
+          MAJOR="${VERSION%%.*}"
+          MINOR_PATCH="${VERSION#*.}"   # e.g. "6.4"
+          MINOR="${MAJOR}.${MINOR_PATCH%.*}"  # e.g. "1.6"
+
+          echo "tag=${TAG}"         >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "major=${MAJOR}"     >> "$GITHUB_OUTPUT"
+          echo "minor=${MINOR}"     >> "$GITHUB_OUTPUT"
+
+  # ── 2. Build & test ────────────────────────────────────────────────────────
+  build-test:
+    needs: prepare
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: node --test
+
+  # ── 3. Docker → GHCR ──────────────────────────────────────────────────────
+  docker:
+    needs: [prepare, build-test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract changelog notes for this version
+        id: changelog
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md)
+          echo "${NOTES}" > /tmp/release_notes.md
+          echo "notes_file=/tmp/release_notes.md" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.version }}
+            ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.minor }}
+            ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.major }}
+            ghcr.io/${{ github.repository }}:latest
+          labels: |
+            org.opencontainers.image.title=mcp-arr
+            org.opencontainers.image.description=MCP server for *arr media management suite
+            org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── 4. GitHub Release ─────────────────────────────────────────────────────
+  github-release:
+    needs: [prepare, build-test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract changelog notes for this version
+        id: changelog
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md)
+          echo "${NOTES}" > /tmp/release_notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          name: ${{ needs.prepare.outputs.tag }}
+          body_path: /tmp/release_notes.md
+          draft: false
+          prerelease: false
+
+  # ── 5. npm publish ────────────────────────────────────────────────────────
+  npm-publish:
+    needs: [prepare, build-test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  mcp-arr:
+    image: ghcr.io/alejandrosnz/mcp-arr:latest
+    container_name: mcp-arr
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      # Transport mode: "http" or "stdio" (default)
+      MCP_TRANSPORT: http
+      HOST: 0.0.0.0
+      PORT: 3000
+      MCP_PATH: /mcp
+      # Sonarr
+      SONARR_URL: ${SONARR_URL:-}
+      SONARR_API_KEY: ${SONARR_API_KEY:-}
+      # Radarr
+      RADARR_URL: ${RADARR_URL:-}
+      RADARR_API_KEY: ${RADARR_API_KEY:-}
+      # Lidarr
+      LIDARR_URL: ${LIDARR_URL:-}
+      LIDARR_API_KEY: ${LIDARR_API_KEY:-}
+      # Prowlarr
+      PROWLARR_URL: ${PROWLARR_URL:-}
+      PROWLARR_API_KEY: ${PROWLARR_API_KEY:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
   mcp-arr:
-    image: ghcr.io/alejandrosnz/mcp-arr:latest
+    image: ghcr.io/aplaceforallmystuff/mcp-arr:latest
     container_name: mcp-arr
     restart: unless-stopped
     ports:
       - "3000:3000"
     environment:
-      # Transport mode: "http" or "stdio" (default)
+      # Setup HTTP Transport mode
       MCP_TRANSPORT: http
       HOST: 0.0.0.0
       PORT: 3000

--- a/src/index.ts
+++ b/src/index.ts
@@ -2431,12 +2431,6 @@ function formatBytes(bytes: number): string {
 }
 
 async function startHttpServer() {
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: undefined, // stateless mode: no session state, avoids "Server already initialized" errors
-  });
-
-  await server.connect(transport);
-
   const httpServer = createServer(async (req, res) => {
     if (!req.url) {
       res.statusCode = 400;
@@ -2464,6 +2458,15 @@ async function startHttpServer() {
     }
 
     try {
+      // Create a fresh stateless transport per request. Each request is independent
+      // (stateless mode), so we close any previous transport before connecting the new one.
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined, // stateless: no session ID issued
+      });
+      if (server.transport) {
+        await server.transport.close();
+      }
+      await server.connect(transport);
       await transport.handleRequest(req, res);
     } catch (error) {
       res.statusCode = 500;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2432,7 +2432,7 @@ function formatBytes(bytes: number): string {
 
 async function startHttpServer() {
   const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: randomUUID,
+    sessionIdGenerator: undefined, // stateless mode: no session state, avoids "Server already initialized" errors
   });
 
   await server.connect(transport);

--- a/test/http-transport.test.mjs
+++ b/test/http-transport.test.mjs
@@ -37,17 +37,18 @@ test("HTTP transport supports multiple requests in one MCP session", async () =>
     });
 
     assert.equal(initializeResponse.status, 200);
+
+    // In stateless mode the server does not issue a session ID; that is expected.
     const sessionId = initializeResponse.headers.get("mcp-session-id");
-    assert.ok(sessionId, "initialize response should include an MCP session id");
 
     const toolsResponse = await postMcp(
       port,
       { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
-      sessionId,
+      sessionId ?? undefined,
     );
 
-    assert.equal(toolsResponse.status, 200);
     const body = await toolsResponse.text();
+    assert.equal(toolsResponse.status, 200);
     assert.match(body, /"tools"/);
     assert.doesNotMatch(body, /Stateless transport cannot be reused/);
   } finally {


### PR DESCRIPTION
## Context

The project had no automated release process — every publish was manual.
This PR adds a complete CI/CD pipeline so releases can be triggered with
a single git tag or a click from the Actions tab.

---

## Release pipeline (`release.yml`) — new

Triggered in two ways:
- **Push a semver tag** (`v*.*.*`) — the classic `git tag v1.6.4 && git push --tags`
- **`workflow_dispatch`** — run it manually from GitHub Actions UI, entering just the
  version number; the workflow creates and pushes the tag itself

The pipeline has 4 parallel jobs that all require the build+test job to pass first:

### 1. `prepare`
Resolves the version from either the pushed tag or the manual input.
Validates that if the tag already exists it points to HEAD (prevents accidental
re-releases of old commits). Outputs `version`, `tag`, `major` and `minor`
for downstream jobs.

### 2. `build-test`
Full quality gate before anything is published:
- `npm ci` → `npm run build` → `tsc --noEmit` → `node --test`

### 3. `docker` → GHCR
Builds a multi-arch image (`linux/amd64` + `linux/arm64`) with Docker Buildx
and pushes it to `ghcr.io` with four tags so users can pin at any granularity:

| Tag | Example | Updates on… |
|---|---|---|
| `latest` | `mcp-arr:latest` | every release |
| major | `mcp-arr:1` | every 1.x release |
| minor | `mcp-arr:1.6` | every 1.6.x release |
| exact | `mcp-arr:1.6.4` | this release only |

Uses GitHub Actions cache (`type=gha`) to speed up layer rebuilds.
Auth via the built-in `GITHUB_TOKEN` — no extra secrets needed.

### 4. `github-release`
Creates a GitHub Release automatically. The release notes are extracted
directly from `CHANGELOG.md` using `awk`, so there's no duplication —
just keep the changelog up to date and the release writes itself.

### 5. `npm-publish`
Publishes the package to npm. Requires a repository secret `NPM_TOKEN`.

---

## Docker Compose (`docker-compose.yml`) — new

Ready-to-use compose file for self-hosters

---

## HTTP transport bug fix

The `StreamableHTTPServerTransport` was shared as a singleton, causing
`"Server already initialized"` on any request after the first. Fixed by
creating a fresh stateless transport per request and closing the previous
one before reconnecting. Covered by `test/http-transport.test.mjs`.

Tested end-to-end with **n8n** and **MCP Inspector**.
<img width="1868" height="1080" alt="image" src="https://github.com/user-attachments/assets/3dd11dae-dec3-4b2e-b495-5259cad0a8f8" />

<img width="1914" height="1951" alt="image" src="https://github.com/user-attachments/assets/e99341ae-7a41-46d8-bd30-d3e24dd4b790" />

