### PR TITLE
fix: use per-request stateless transport for HTTP mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.6.4] - 2026-05-22
+
+### Fixed
+- Fixed HTTP MCP mode failing with clients (e.g. Claude Code) that do not include `Mcp-Session-Id` in post-initialization requests by switching to a stateless per-request transport (`sessionIdGenerator: undefined`). Each POST creates a fresh transport; the shared server instance retains all registered tools between requests.
+
 ## [1.6.3] - 2026-04-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-arr-server",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "mcpName": "io.github.aplaceforallmystuff/mcp-arr",
   "description": "MCP server for *arr media management suite - Sonarr, Radarr, Lidarr, Prowlarr",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2431,12 +2431,6 @@ function formatBytes(bytes: number): string {
 }
 
 async function startHttpServer() {
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: randomUUID,
-  });
-
-  await server.connect(transport);
-
   const httpServer = createServer(async (req, res) => {
     if (!req.url) {
       res.statusCode = 400;
@@ -2463,11 +2457,21 @@ async function startHttpServer() {
       return;
     }
 
+    // Create a fresh stateless transport per request so that MCP clients
+    // which do not include Mcp-Session-Id headers (e.g. Claude Code) work
+    // correctly. Each POST is handled independently; the shared `server`
+    // instance retains all registered tools across requests.
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
     try {
+      await server.connect(transport);
       await transport.handleRequest(req, res);
     } catch (error) {
       res.statusCode = 500;
       res.end(error instanceof Error ? error.message : String(error));
+    } finally {
+      await transport.close();
     }
   });
 


### PR DESCRIPTION
## Problem

MCP clients such as **Claude Code** initialize a session but do not include the `Mcp-Session-Id` header in subsequent requests. With the current single shared transport (`sessionIdGenerator: randomUUID`), every post-initialization request fails with:

```
400 Bad Request: Mcp-Session-Id header is required
```

The session is created server-side during `initialize`, but since the client never sends the session ID back, all tool calls are rejected.

## Fix

Switch `startHttpServer()` to create a fresh `StreamableHTTPServerTransport` per POST request with `sessionIdGenerator: undefined` (stateless mode):

- Each request connects a new transport to the shared `McpServer` instance
- `transport.close()` in the `finally` block properly disconnects the server after each request, allowing the next request to reconnect
- Tool registrations on `server` persist across requests — only the transport/session is ephemeral
- No `Mcp-Session-Id` is generated or required, making the server compatible with any MCP client regardless of session ID support

## Testing

Verified against Claude Code v2.1.148 with `--transport http`: `arr_status`, `sonarr_get_series`, `radarr_get_movies`, and tool calls all succeed after this change.