### PR TITLE
fix(http): fresh server per request so a streamable GET stream can't deadlock

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -961,18 +961,31 @@ TOOLS.push(
   }
 );
 
-// Create server instance
-const server = new Server(
-  {
-    name: "mcp-arr",
-    version: SERVER_VERSION,
-  },
-  {
-    capabilities: {
-      tools: {},
+// Build a fresh MCP server instance with all request handlers registered.
+// The HTTP transport builds a new instance per request (see startHttpServer)
+// so concurrent / long-lived transports never share a single server. A shared
+// server can only be connected to one transport at a time, which is why the
+// old code funnelled every request through a serialized queue — and that queue
+// deadlocked the moment a streamable client opened its long-lived GET (SSE)
+// stream, since that request never completes.
+function buildServer(): Server {
+  const server = new Server(
+    {
+      name: "mcp-arr",
+      version: SERVER_VERSION,
     },
-  }
-);
+    {
+      capabilities: {
+        tools: {},
+      },
+    }
+  );
+  registerHandlers(server);
+  return server;
+}
+
+// Module-level instance used by the stdio transport (single, long-lived session).
+const server = buildServer();
 
 type SearchEntry = {
   id: string;
@@ -1200,6 +1213,10 @@ async function getPaginatedQueue(
   };
 }
 
+// Registers the MCP request handlers on a server instance. Called by
+// buildServer() for every server created (one per HTTP request, plus the
+// module-level stdio instance).
+function registerHandlers(server: Server): void {
 // Handle list tools request
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return { tools: TOOLS };
@@ -2581,6 +2598,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     };
   }
 });
+}
 
 // Helper function to format bytes
 function formatBytes(bytes: number): string {
@@ -2589,15 +2607,6 @@ function formatBytes(bytes: number): string {
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
-}
-
-// Serializes HTTP request handling so the shared MCP `server` is only ever
-// connected to one transport at a time (see startHttpServer for why).
-let httpQueue: Promise<unknown> = Promise.resolve();
-function runSerialized<T>(task: () => Promise<T>): Promise<T> {
-  const result = httpQueue.then(task, task);
-  httpQueue = result.catch(() => undefined);
-  return result;
 }
 
 async function startHttpServer() {
@@ -2627,28 +2636,32 @@ async function startHttpServer() {
       return;
     }
 
-    // Stateless HTTP: a fresh transport per request, with no session id issued
-    // (sessionIdGenerator: undefined). This lets MCP clients that do not echo the
-    // Mcp-Session-Id header back — e.g. Claude Code — work, while a fresh transport
-    // per request sidesteps the SDK 1.27.x "stateless transport cannot be reused"
-    // guard. Handling is serialized because the shared `server` can only be
-    // connected to one transport at a time.
-    await runSerialized(async () => {
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-      });
-      try {
-        await server.connect(transport);
-        await transport.handleRequest(req, res);
-      } catch (error) {
-        if (!res.headersSent) {
-          res.statusCode = 500;
-          res.end(error instanceof Error ? error.message : String(error));
-        }
-      } finally {
-        await transport.close();
-      }
+    // Stateless HTTP: a fresh server + transport per request, with no session
+    // id issued (sessionIdGenerator: undefined). This lets MCP clients that do
+    // not echo the Mcp-Session-Id header back — e.g. Claude Code — work. Using a
+    // new server per request means requests are no longer serialized through a
+    // single shared server, so a long-lived GET (SSE) stream can stay open
+    // without blocking other requests. The previous shared-server + serialized
+    // queue deadlocked the moment a streamable client (e.g. a gateway/proxy)
+    // opened its GET stream — that request never completes, so every later
+    // request hung behind it.
+    const requestServer = buildServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
     });
+    res.on("close", () => {
+      void transport.close();
+      void requestServer.close();
+    });
+    try {
+      await requestServer.connect(transport);
+      await transport.handleRequest(req, res);
+    } catch (error) {
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.end(error instanceof Error ? error.message : String(error));
+      }
+    }
   });
 
   await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Problem

Fixes #21.

The `http` transport reuses a single module-level `Server` for every request and serializes them through a global promise queue (`runSerialized`), because one `Server` can only be connected to one transport at a time.

That deadlocks behind any MCP **gateway/proxy** (anything that speaks streamable-HTTP rather than a single long-lived stdio client):

1. A streamable-HTTP client opens a long-lived **GET** (`Accept: text/event-stream`) request to the MCP endpoint — the server→client SSE channel. Its `transport.handleRequest(req, res)` does not resolve while the stream is open.
2. Because every request runs through the same serialized queue, that one open GET **blocks the queue permanently**.
3. Every subsequent `POST` (initialize, `tools/list`, `tools/call`, …) hangs with no response. The server passes its first health/validation probe, then silently stops answering. `/health` keeps working because it's handled before the queue.

This is invisible to a single client (one short request at a time completes fine), which is why it only shows up behind a gateway.

### Reproduction (against the current `main`)

```
# baseline POST works
curl -XPOST :3000/mcp -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"initialize",...}'   # 200

# open a long-lived GET SSE stream in the background, then POST again:
curl -N :3000/mcp -H 'Accept: text/event-stream' &        # held open
curl -XPOST :3000/mcp ... -d '{...initialize...}'          # hangs → no response (000 / timeout)
```

## Fix

Switch to the MCP SDK's documented **stateless** pattern: build a fresh `Server` + `StreamableHTTPServerTransport` per request, close both when the response closes, and drop the serialized queue entirely. Requests no longer share a `Server`, so a long-lived GET stream can't block other requests.

- `buildServer()` factory + `registerHandlers(server)` so each instance gets the same handlers.
- HTTP path creates `buildServer()` per request, `res.on("close", …)` tears it down.
- `runSerialized`/`httpQueue` removed.
- stdio transport unchanged — still one long-lived module-level `Server`.

## Verification

With a GET SSE stream held open:

| | before | after |
|---|---|---|
| POST while GET open | times out, no response | **200 in ~9ms** |
| concurrent POSTs while GET open | hang | all **200** |

`npm run build` and `npm test` pass.