### PR TITLE
Pin hono to 4.12.25 to clear security advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.22",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
-      "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aplaceforallmystuff/mcp-arr.git"
+  },
+  "overrides": {
+    "hono": "4.12.25"
   }
 }


### PR DESCRIPTION
## Summary

Adds an npm `overrides` entry to force `hono` to `4.12.25`, resolving the following advisories affecting `hono <=4.12.24`:

- GHSA-wwfh-h76j-fc44 — Path traversal in `serve-static` on Windows via encoded backslash
- GHSA-j6c9-x7qj-28xf — AWS Lambda adapter merges multiple `Set-Cookie` headers
- GHSA-88fw-hqm2-52qc — CORS Middleware reflects any Origin with credentials
- GHSA-rv63-4mwf-qqc2 — Body Limit Middleware bypass on AWS Lambda
- GHSA-wgpf-jwqj-8h8p — Lambda@Edge adapter drops repeated request headers

`npm audit --omit=dev` reports 0 vulnerabilities after this change.

## Test plan

- [ ] `npm install` completes cleanly
- [ ] `npm audit --omit=dev` reports 0 vulnerabilities
- [ ] Existing tests pass